### PR TITLE
reinstate rho=Exner*Psi to fix schaerWaves instability

### DIFF
--- a/applications/solvers/ExnerFoam/ExnerFoamH/exnerEqn.H
+++ b/applications/solvers/ExnerFoam/ExnerFoamH/exnerEqn.H
@@ -1,6 +1,6 @@
 {
     Psi == pow(rho,(2*kappa-1)/(kappa-1))*pow(R/pRef*theta, kappa/(kappa-1));
-    //rho = Exner*Psi;
+    rho = Exner*Psi;
     rhof = fvc::interpolate(rho);
 
     surfaceScalarField G("G", 1+offCentre*dt*muSponge);


### PR DESCRIPTION
This partially reverts commit dccfdc93 from May 2017.  I'm not sure why this line was commented out but it appears to be necessary for solving the schaerWaves test case.