### PR TITLE
Implement findAdjacentPrisms app

### DIFF
--- a/applications/utilities/mesh/findAdjacentPrisms/Make/files
+++ b/applications/utilities/mesh/findAdjacentPrisms/Make/files
@@ -1,0 +1,3 @@
+findAdjacentPrisms.C
+
+EXE = $(FOAM_USER_APPBIN)/findAdjacentPrisms

--- a/applications/utilities/mesh/findAdjacentPrisms/Make/options
+++ b/applications/utilities/mesh/findAdjacentPrisms/Make/options
@@ -1,0 +1,7 @@
+EXE_INC = \
+    -I$(LIB_SRC)/finiteVolume/lnInclude \
+    -I$(LIB_SRC)/meshTools/lnInclude
+
+EXE_LIBS = \
+    -lfiniteVolume \
+    -lmeshTools

--- a/applications/utilities/mesh/findAdjacentPrisms/findAdjacentPrisms.C
+++ b/applications/utilities/mesh/findAdjacentPrisms/findAdjacentPrisms.C
@@ -1,0 +1,72 @@
+/*---------------------------------------------------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     |
+    \\  /    A nd           | Copyright (C) 2017 OpenFOAM Foundation
+     \\/     M anipulation  |
+-------------------------------------------------------------------------------
+License
+    This file is part of OpenFOAM.
+
+    OpenFOAM is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+    for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with OpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
+
+Application
+    findAdjacentPrisms
+
+Description
+    Write a faceSet containing interior faces that connect two prisms.
+    Designed to be used in conjunction with slantedCellMesh to improve
+    mesh quality by merging triangular (prismatic) slanted cells found
+    near the lower boundary of slanted cell meshes.
+
+\*---------------------------------------------------------------------------*/
+
+#include "fvCFD.H"
+#include "faceSet.H"
+#include "prismMatcher.H"
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+int main(int argc, char *argv[])
+{
+    #include "setRootCase.H"
+    #include "createTime.H"
+    #include "createMesh.H"
+
+    faceSet adjacentPrismSet(mesh, "adjacentPrismSet", IOobject::NO_READ, IOobject::AUTO_WRITE);
+    prismMatcher prism;
+
+    for (label faceI = 0; faceI < mesh.nInternalFaces(); faceI++)
+    {
+        const label& own = mesh.faceOwner()[faceI];
+        const label& neighbour = mesh.faceNeighbour()[faceI];
+
+        if (prism.isA(mesh, own) && prism.isA(mesh, neighbour))
+        {
+            adjacentPrismSet.insert(faceI);
+        }
+    }
+
+    adjacentPrismSet.write();
+
+    Info << "Written " << adjacentPrismSet.size() << " faces with two adjacent prisms to adjacentPrismSet" << endl;
+
+    // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+    Info<< "End\n" << endl;
+
+    return 0;
+}
+
+// ************************************************************************* //


### PR DESCRIPTION
This app helps me to merge slanted cells together by finding adjacent prismatic cells (that is, extruded triangles).  The app writes a faceSet for such cells and I use [removeFaces](https://github.com/OpenFOAM/OpenFOAM-dev/tree/master/applications/utilities/mesh/advanced/removeFaces) to merge those cells together.

Clearly merging *all* triangles is perhaps not the smartest approach for at least three reasons:
1. I might merge adjacent triangles belonging to two different columns
2. I might merge many triangles together to form one triangle that is far larger than the typical cell in a mesh
3. I end up with hanging nodes (the approach is a non-conforming coarsening of the mesh if you will)

Nevertheless, this seems like a reasonable idea.  Once merged into master I might see if slanted cell merging can help reduce some numerical errors.