### PR TITLE
Add total tracer diagnostics to advection solvers

### DIFF
--- a/applications/solvers/advection/advectionFoam/advectionFoam.C
+++ b/applications/solvers/advection/advectionFoam/advectionFoam.C
@@ -25,8 +25,8 @@ Application
     advectionFoam
 
 Description
-    Solves a transport equation for a passive scalar using explicit leap-frog
-    time-stepping or RK2
+    Solves a transport equation for a passive scalar using an explicit
+    time-stepping method.
 
 \*---------------------------------------------------------------------------*/
 
@@ -50,6 +50,8 @@ int main(int argc, char *argv[])
     #include "createMesh.H"
     #define dt runTime.deltaT()
     #include "createFields.H"
+    #include "initEnergy.H"
+    #include "energy.H"
 
     Info<< "\nCalculating advection\n" << endl;
 
@@ -129,6 +131,8 @@ int main(int argc, char *argv[])
         Info << " T goes from " << min(T.internalField()) << " to "
              << max(T.internalField()) << endl;
         runTime.write();
+
+        #include "energy.H"
 
         if (timeVaryingWind)
         {

--- a/applications/solvers/advection/advectionFoam/energy.H
+++ b/applications/solvers/advection/advectionFoam/energy.H
@@ -1,0 +1,6 @@
+{
+    const dimensionedScalar totalSum = fvc::domainIntegrate(T)/totalV;
+    const dimensionedScalar diffNorm = (totalSum - totalInitialSum)/totalInitialSum;
+    es << runTime.timeName() << " "
+       << diffNorm.value() << endl;
+}

--- a/applications/solvers/advection/advectionFoam/initEnergy.H
+++ b/applications/solvers/advection/advectionFoam/initEnergy.H
@@ -1,0 +1,7 @@
+Info << "Initialising total energy file energy.dat\n" << endl;
+
+OFstream es(args.rootPath() / args.caseName() / "energy.dat");
+es << "#time normalisedSum" << endl;
+
+const dimensionedScalar totalV = sum(mesh.V());
+const dimensionedScalar totalInitialSum = fvc::domainIntegrate(T)/totalV;

--- a/applications/solvers/advection/advectiveFoamF/advectiveFoamF.C
+++ b/applications/solvers/advection/advectiveFoamF/advectiveFoamF.C
@@ -45,8 +45,10 @@ int main(int argc, char *argv[])
     #define dt runTime.deltaT()
     #include "createGravity.H"
     #include "createVolInterpolation.H"
-    #include "createFields.H"
     #include "createSurfaceGrad.H"
+    #include "createFields.H"
+    #include "initEnergy.H"
+    #include "energy.H"
 
     Info<< "\nCalculating advection\n" << endl;
 
@@ -76,6 +78,7 @@ int main(int argc, char *argv[])
         Info << " T goes from " << min(T.internalField()) << " to "
              << max(T.internalField()) << endl;
         runTime.write();
+        #include "energy.H"
     }
 
     Info<< "End\n" << endl;

--- a/applications/solvers/advection/advectiveFoamF/advectiveFoamF.C
+++ b/applications/solvers/advection/advectiveFoamF/advectiveFoamF.C
@@ -47,14 +47,15 @@ int main(int argc, char *argv[])
     #include "createVolInterpolation.H"
     #include "createSurfaceGrad.H"
     #include "createFields.H"
-    #include "initEnergy.H"
-    #include "energy.H"
 
     Info<< "\nCalculating advection\n" << endl;
 
     #include "CourantNo.H"
 
     Tf = Tf * mag(g.unitFaceNormal()) + (1.0 - mag(g.unitFaceNormal()))*fvc::interpolate(T);
+
+    #include "initEnergy.H"
+    #include "energy.H"
 
     while (runTime.loop())
     {

--- a/applications/solvers/advection/advectiveFoamF/energy.H
+++ b/applications/solvers/advection/advectiveFoamF/energy.H
@@ -1,0 +1,19 @@
+{
+    scalar totalA = 0;
+    scalar totalSum = 0;
+
+    forAll(Tf, facei)
+    {
+        const scalar value = Tf[facei];
+        const scalar area = mesh.delta()()[facei] & mesh.Sf()[facei];
+        totalA += area;
+        totalSum += value*area;
+    }
+
+    totalSum /= totalA;
+
+    const dimensionedScalar diffNorm = (totalSum - totalInitialSum)/totalInitialSum;
+
+    es << runTime.timeName() << " "
+       << diffNorm.value() << endl;
+}

--- a/applications/solvers/advection/advectiveFoamF/initEnergy.H
+++ b/applications/solvers/advection/advectiveFoamF/initEnergy.H
@@ -1,0 +1,17 @@
+Info << "Initialising total energy file energy.dat\n" << endl;
+
+OFstream es(args.rootPath() / args.caseName() / "energy.dat");
+es << "#time normalisedSum" << endl;
+
+scalar totalA = 0;
+scalar totalInitialSum = 0;
+
+forAll(Tf, facei)
+{
+    const scalar value = Tf[facei];
+    const scalar area = mesh.delta()()[facei] & mesh.Sf()[facei];
+    totalA += area;
+    totalInitialSum += value*area;
+}
+
+totalInitialSum /= totalA;

--- a/applications/solvers/advection/sphericalAdvectionFoam/energy.H
+++ b/applications/solvers/advection/sphericalAdvectionFoam/energy.H
@@ -1,0 +1,6 @@
+{
+    const dimensionedScalar totalSum = fvc::domainIntegrate(T)/totalV;
+    const dimensionedScalar diffNorm = (totalSum - totalInitialSum)/totalInitialSum;
+    es << runTime.timeName() << " "
+       << diffNorm.value() << endl;
+}

--- a/applications/solvers/advection/sphericalAdvectionFoam/initEnergy.H
+++ b/applications/solvers/advection/sphericalAdvectionFoam/initEnergy.H
@@ -1,0 +1,7 @@
+Info << "Initialising total energy file energy.dat\n" << endl;
+
+OFstream es(args.rootPath() / args.caseName() / "energy.dat");
+es << "#time normalisedSum" << endl;
+
+const dimensionedScalar totalV = sum(mesh.V());
+const dimensionedScalar totalInitialSum = fvc::domainIntegrate(T)/totalV;


### PR DESCRIPTION
Following the energy.dat diagnostics in ExnerFoam solvers, I've implemented similar measures for `advectionFoam` and `advectiveFoamF` (the Charney--Phillips variant).

Regarding the calculation of volume-weighted integrals of surface fields, I haven't thought too hard about the best way to do it for 2D/3D.  There's a little bit of duplication here that could go into a custom `fvc::domainIntegrate(surface field)` implementation, maybe in AtmosFOAM-tools.  But that seemed like overkill for now :smiley: 